### PR TITLE
feat(#5): wraps telepresence in ike develop cmd

### DIFF
--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -39,7 +39,9 @@ var developCmd = &cobra.Command{
 	Long:  `TODO`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		checkIfTelepresenceExists()
+		if !telepresenceExists() {
+			os.Exit(1)
+		}
 
 		var tp = exec.Command(telepresenceBin, parseArguments()...)
 
@@ -94,14 +96,15 @@ func parseArguments() []string {
 		"--run"}, runArgs...)
 }
 
-func checkIfTelepresenceExists() {
+func telepresenceExists() bool {
 	path, err := exec.LookPath(telepresenceBin)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Couldn't find '%s' installed in your system.\n"+
 			"Head over to https://www.telepresence.io/reference/install for installation instructions.\n", telepresenceBin))
-		os.Exit(1)
+		return false
 	} else {
 		log.Info(fmt.Sprintf("Found '%s' executable in '%s'.", telepresenceBin, path))
 		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution.", telepresenceBin))
+		return true
 	}
 }

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -21,6 +21,10 @@ var (
 )
 
 func init() {
+	// -- config (bound with viper?)
+	// -- build command
+	// --watch to rebuild ---> see skaffold samples for node and python
+	// -- testing ?
 	developCmd.PersistentFlags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
 	developCmd.PersistentFlags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
 	developCmd.PersistentFlags().StringVarP(&runnable, "run", "r", "", "command to run your application")
@@ -77,6 +81,11 @@ func redirectStreams(command *exec.Cmd) {
 		_, errStderr = io.Copy(stderr, stderrIn)
 		wg.Done()
 	}()
+
+	if errStderr != nil || errStdout != nil {
+		log.V(9).Info("Failed to copy either of stdout or stderr")
+	}
+
 	wg.Wait()
 }
 
@@ -95,7 +104,7 @@ func checkIfTelepresenceExists() {
 		log.Error(err, fmt.Sprintf("Couldn't find '%s' installed in your system.\n"+
 			"Head over to https://www.telepresence.io/reference/install for installation instructions.\n", telepresenceBin))
 	} else {
-		log.Info(fmt.Sprintf("Found '%s' executable in '%s'\n", telepresenceBin, path))
-		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution\n", telepresenceBin))
+		log.Info(fmt.Sprintf("Found '%s' executable in '%s'.", telepresenceBin, path))
+		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution.", telepresenceBin))
 	}
 }

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	deploymentName string
+	port           int
+	runnable       string
+	method         string
+)
+
+func init() {
+	developCmd.PersistentFlags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
+	developCmd.PersistentFlags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
+	developCmd.PersistentFlags().StringVarP(&runnable, "run", "r", "", "command to run your application")
+	developCmd.PersistentFlags().StringVarP(&method, "method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
+
+	_ = developCmd.MarkPersistentFlagRequired("deployment")
+	_ = developCmd.MarkPersistentFlagRequired("run")
+	rootCmd.AddCommand(developCmd)
+}
+
+const telepresenceBin = "telepresence"
+
+var developCmd = &cobra.Command{
+	Use:   "develop",
+	Short: "starts the development flow",
+	Long:  `TODO`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		checkIfTelepresenceExists()
+
+		var tp = exec.Command(telepresenceBin, parseArguments()...)
+
+		redirectStreams(tp)
+
+		err := tp.Wait()
+
+		if err != nil {
+			log.Error(err, fmt.Sprintf("%s failed", telepresenceBin))
+			os.Exit(1)
+		}
+
+	},
+}
+
+func redirectStreams(command *exec.Cmd) {
+	stdoutIn, _ := command.StdoutPipe()
+	stderrIn, _ := command.StderrPipe()
+	var stdoutBuf, stderrBuf bytes.Buffer
+	stdout := io.MultiWriter(os.Stdout, &stdoutBuf)
+	stderr := io.MultiWriter(os.Stderr, &stderrBuf)
+	var errStdout, errStderr error
+	err := command.Start()
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to start '%s'", telepresenceBin))
+		os.Exit(1)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		_, errStdout = io.Copy(stdout, stdoutIn)
+		wg.Done()
+	}()
+	go func() {
+		_, errStderr = io.Copy(stderr, stderrIn)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func parseArguments() []string {
+	runArgs := strings.Split(runnable, " ")
+	return append([]string{
+		"--swap-deployment", deploymentName,
+		"--expose", strconv.Itoa(port),
+		"--method", method,
+		"--run"}, runArgs...)
+}
+
+func checkIfTelepresenceExists() {
+	path, err := exec.LookPath(telepresenceBin)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Couldn't find '%s' installed in your system.\n"+
+			"Head over to https://www.telepresence.io/reference/install for installation instructions.\n", telepresenceBin))
+	} else {
+		log.Info(fmt.Sprintf("Found '%s' executable in '%s'\n", telepresenceBin, path))
+		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution\n", telepresenceBin))
+	}
+}

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -102,9 +102,10 @@ func telepresenceExists() bool {
 		log.Error(err, fmt.Sprintf("Couldn't find '%s' installed in your system.\n"+
 			"Head over to https://www.telepresence.io/reference/install for installation instructions.\n", telepresenceBin))
 		return false
-	} else {
-		log.Info(fmt.Sprintf("Found '%s' executable in '%s'.", telepresenceBin, path))
-		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution.", telepresenceBin))
-		return true
 	}
+
+	log.Info(fmt.Sprintf("Found '%s' executable in '%s'.", telepresenceBin, path))
+	log.Info(fmt.Sprintf("See '%s.log' for more details about its execution.", telepresenceBin))
+
+	return true
 }

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -21,10 +21,6 @@ var (
 )
 
 func init() {
-	// -- config (bound with viper?)
-	// -- build command
-	// --watch to rebuild ---> see skaffold samples for node and python
-	// -- testing ?
 	developCmd.PersistentFlags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
 	developCmd.PersistentFlags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
 	developCmd.PersistentFlags().StringVarP(&runnable, "run", "r", "", "command to run your application")

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -99,6 +99,7 @@ func checkIfTelepresenceExists() {
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Couldn't find '%s' installed in your system.\n"+
 			"Head over to https://www.telepresence.io/reference/install for installation instructions.\n", telepresenceBin))
+		os.Exit(1)
 	} else {
 		log.Info(fmt.Sprintf("Found '%s' executable in '%s'.", telepresenceBin, path))
 		log.Info(fmt.Sprintf("See '%s.log' for more details about its execution.", telepresenceBin))

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -10,7 +10,7 @@ func main() {
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(true))
+	logf.SetLogger(logf.ZapLogger(false))
 
 	cmd.Execute()
 }

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -10,7 +10,7 @@ func main() {
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(logf.ZapLogger(true))
 
 	cmd.Execute()
 }


### PR DESCRIPTION
```
Usage:
  ike develop [flags]

Flags:
  -d, --deployment string   name of the deployment or deployment config
  -h, --help                help for develop
  -m, --method string       telepresence proxying mode - see https://www.telepresence.io/reference/methods (default "inject-tcp")
  -p, --port int            port to be exposed (default 8000)
  -r, --run string          command to run your application
```