### PR TITLE
feat(deploy): introduces template for operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ DOCKER?=$(if $(or $(in_docker_group),$(is_root)),docker,sudo docker)
 DOCKER_IMAGE?=$(PROJECT_NAME)
 DOCKER_REPO?=docker.io/aslakknutsen
 
+.PHONY: deploy-operator
 docker-build: ## Builds the docker image
 	@echo "Building docker image $(DOCKER_IMAGE_CORE)"
 	$(DOCKER) build \
@@ -82,7 +83,7 @@ docker-build: ## Builds the docker image
 		$(DOCKER_REPO)/$(DOCKER_IMAGE):latest
 
 # istio example deployment
-.PHONY:
+.PHONY: deploy-operator
 deploy-operator:
 	@echo "Deploying operator to $(OPERATOR_NAMESPACE)"
 	oc apply -f deploy/crds/istio_v1alpha1_session_crd.yaml -n $(OPERATOR_NAMESPACE)
@@ -91,7 +92,7 @@ deploy-operator:
 	oc apply -f deploy/role_binding.yaml -n $(OPERATOR_NAMESPACE)
 	oc apply -f deploy/operator.yaml -n $(OPERATOR_NAMESPACE)
 
-.PHONY:
+.PHONY: undeploy-operator
 undeploy-operator:
 	@echo "UnDeploying operator to $(OPERATOR_NAMESPACE)"
 	oc delete -f deploy/operator.yaml -n $(OPERATOR_NAMESPACE)
@@ -100,12 +101,12 @@ undeploy-operator:
 	oc delete -f deploy/service_account.yaml -n $(OPERATOR_NAMESPACE)
 	oc delete -f deploy/crds/istio_v1alpha1_session_crd.yaml -n $(OPERATOR_NAMESPACE)
 
-.PHONY:
+.PHONY: deploy-example
 deploy-example:
 	@echo "Deploying operator to $(EXAMPLE_NAMESPACE)"
 	oc apply -f deploy/crds/istio_v1alpha1_session_cr.yaml -n $(EXAMPLE_NAMESPACE)
 
-.PHONY:
+.PHONY: undeploy-example
 undeploy-example:
 	@echo "UnDeploying operator to $(EXAMPLE_NAMESPACE)"
 	oc delete -f deploy/crds/istio_v1alpha1_session_cr.yaml -n $(EXAMPLE_NAMESPACE)

--- a/Makefile
+++ b/Makefile
@@ -86,27 +86,27 @@ docker-build: ## Builds the docker image
 .PHONY: deploy-operator
 deploy-operator:
 	@echo "Deploying operator to $(OPERATOR_NAMESPACE)"
-	oc apply -f deploy/crds/istio_v1alpha1_session_crd.yaml -n $(OPERATOR_NAMESPACE)
-	oc apply -f deploy/service_account.yaml -n $(OPERATOR_NAMESPACE)
-	oc apply -f deploy/role.yaml -n $(OPERATOR_NAMESPACE)
-	oc apply -f deploy/role_binding.yaml -n $(OPERATOR_NAMESPACE)
-	oc apply -f deploy/operator.yaml -n $(OPERATOR_NAMESPACE)
+	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/crds/istio_v1alpha1_session_crd.yaml
+	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/service_account.yaml
+	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/role.yaml
+	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/role_binding.yaml
+	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/operator.yaml
 
 .PHONY: undeploy-operator
 undeploy-operator:
 	@echo "UnDeploying operator to $(OPERATOR_NAMESPACE)"
-	oc delete -f deploy/operator.yaml -n $(OPERATOR_NAMESPACE)
-	oc delete -f deploy/role_binding.yaml -n $(OPERATOR_NAMESPACE)
-	oc delete -f deploy/role.yaml -n $(OPERATOR_NAMESPACE)
-	oc delete -f deploy/service_account.yaml -n $(OPERATOR_NAMESPACE)
-	oc delete -f deploy/crds/istio_v1alpha1_session_crd.yaml -n $(OPERATOR_NAMESPACE)
+	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/operator.yaml
+	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/role_binding.yaml
+	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/role.yaml
+	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/service_account.yaml
+	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/crds/istio_v1alpha1_session_crd.yaml
 
 .PHONY: deploy-example
 deploy-example:
 	@echo "Deploying operator to $(EXAMPLE_NAMESPACE)"
-	oc apply -f deploy/crds/istio_v1alpha1_session_cr.yaml -n $(EXAMPLE_NAMESPACE)
+	oc apply -n $(EXAMPLE_NAMESPACE) -f deploy/crds/istio_v1alpha1_session_cr.yaml
 
 .PHONY: undeploy-example
 undeploy-example:
 	@echo "UnDeploying operator to $(EXAMPLE_NAMESPACE)"
-	oc delete -f deploy/crds/istio_v1alpha1_session_cr.yaml -n $(EXAMPLE_NAMESPACE)
+	oc delete -n $(EXAMPLE_NAMESPACE) -f deploy/crds/istio_v1alpha1_session_cr.yaml

--- a/Makefile
+++ b/Makefile
@@ -70,17 +70,18 @@ $(BINARY_DIR)/$(BINARY_NAME): $(BINARY_DIR) $(SRCS)
 
 DOCKER?=$(if $(or $(in_docker_group),$(is_root)),docker,sudo docker)
 DOCKER_IMAGE?=$(PROJECT_NAME)
-DOCKER_REPO?=docker.io/aslakknutsen
+DOCKER_REGISTRY?=docker.io
+DOCKER_REPOSITORY?=aslakknutsen
 
 .PHONY: deploy-operator
 docker-build: ## Builds the docker image
 	@echo "Building docker image $(DOCKER_IMAGE_CORE)"
 	$(DOCKER) build \
-		-t $(DOCKER_REPO)/$(DOCKER_IMAGE):$(COMMIT) \
+		-t $(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY)/$(DOCKER_IMAGE):$(COMMIT) \
 		-f $(BUILD_DIR)/Dockerfile $(CUR_DIR)
 	$(DOCKER) tag \
-		$(DOCKER_REPO)/$(DOCKER_IMAGE):$(COMMIT) \
-		$(DOCKER_REPO)/$(DOCKER_IMAGE):latest
+		$(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY)/$(DOCKER_IMAGE):$(COMMIT) \
+		$(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY)/$(DOCKER_IMAGE):latest
 
 # istio example deployment
 .PHONY: deploy-operator

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ BUILD_TIME=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GITUNTRACKEDCHANGES:=$(shell git status --porcelain --untracked-files=no)
 COMMIT:=$(shell git rev-parse --short HEAD)
 ifneq ($(GITUNTRACKEDCHANGES),)
-  COMMIT := $(COMMIT)-dirty
+	COMMIT := $(COMMIT)-dirty
 endif
 VERSION?=0.0.1
 LDFLAGS="-w -X ${PACKAGE_NAME}/version.Version=${VERSION} -X ${PACKAGE_NAME}/version.Commit=${COMMIT} -X ${PACKAGE_NAME}/version.BuildTime=${BUILD_TIME}"
@@ -84,6 +84,17 @@ docker-build: ## Builds the docker image
 		$(DOCKER_REGISTRY)/$(DOCKER_REPOSITORY)/$(DOCKER_IMAGE):latest
 
 # istio example deployment
+
+define process_template # params: template location
+	@oc process -f $(1) \
+		-o yaml \
+		--local \
+		-p DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
+		-p DOCKER_REPOSITORY=$(DOCKER_REPOSITORY) \
+		-p IMAGE_NAME=$(DOCKER_IMAGE) \
+		-p IMAGE_TAG=$(COMMIT)
+endef
+
 .PHONY: deploy-operator
 deploy-operator:
 	@echo "Deploying operator to $(OPERATOR_NAMESPACE)"
@@ -91,12 +102,12 @@ deploy-operator:
 	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/service_account.yaml
 	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/role.yaml
 	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/role_binding.yaml
-	oc apply -n $(OPERATOR_NAMESPACE) -f deploy/operator.yaml
+	$(call process_template,deploy/operator.yaml) | oc apply -n $(OPERATOR_NAMESPACE) -f -
 
 .PHONY: undeploy-operator
 undeploy-operator:
 	@echo "UnDeploying operator to $(OPERATOR_NAMESPACE)"
-	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/operator.yaml
+	$(call process_template,deploy/operator.yaml) | oc delete -n $(OPERATOR_NAMESPACE) -f -
 	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/role_binding.yaml
 	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/role.yaml
 	oc delete -n $(OPERATOR_NAMESPACE) -f deploy/service_account.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,30 +1,46 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-workspace
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: istio-workspace
-  template:
+kind: Template
+apiVersion: v1
+parameters:
+  - name: DOCKER_REGISTRY
+    required: true
+    value: docker.io
+  - name: DOCKER_REPOSITORY
+    required: true
+    value: aslakknusten
+  - name: IMAGE_NAME
+    required: true
+    value: istio-workspace
+  - name: IMAGE_TAG
+    required: true
+    value: latest
+objects:
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
-      labels:
-        name: istio-workspace
+      name: istio-workspace
     spec:
-      serviceAccountName: istio-workspace
-      containers:
-        - name: istio-workspace
-          image: docker.io/aslakknutsen/istio-workspace:latest
-          command:
-          - ike
-          imagePullPolicy: Always
-          env:
-            - name: WATCH_NAMESPACE
-              value: ""
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "istio-workspace"
+      replicas: 1
+      selector:
+        matchLabels:
+          name: istio-workspace
+      template:
+        metadata:
+          labels:
+            name: istio-workspace
+        spec:
+          serviceAccountName: istio-workspace
+          containers:
+            - name: istio-workspace
+              image: ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/${IMAGE_NAME}:${IMAGE_TAG}
+              command:
+              - ike
+              imagePullPolicy: Always
+              env:
+                - name: WATCH_NAMESPACE
+                  value: ""
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: "istio-workspace"


### PR DESCRIPTION

* [OpenShift](https://docs.openshift.com/container-platform/3.11/dev_guide/templates.html) template is used to prepare operator object with
image-related variables such as registry, repository, image name and tag
(with defaults)
* Makefile processes the template before deploying operator and passes
relevant key=values (can be overwritten during build e.g.
`IMAGE_TAG=latest make docker-build`)

Closes #7