### PR TITLE
feat(linter): introduces linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 10
+  dupl:
+    threshold: 128
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  depguard:
+    list-type: blacklist
+    packages:
+      # logging is allowed only by logutils.Log, logrus
+      # is allowed to use only in logutils package
+      - github.com/sirupsen/logrus
+  misspell:
+    locale: US
+  lll:
+    line-length: 180
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  gocritic:
+    enabled-tags:
+      - performance
+      - style
+      - experimental
+    disabled-checks:
+      - wrapperFunc
+      - commentFormatting # https://github.com/go-critic/go-critic/issues/755
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - prealloc
+    - gochecknoglobals
+
+service:
+  project-path: github.com/arquillian/ike-prow-plugins
+  prepare:
+    - make tools deps generate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,15 +13,14 @@ linters-settings:
   depguard:
     list-type: blacklist
     packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
+      # logging is allowed only by "sigs.k8s.io/controller-runtime/pkg/runtime/log"
       - github.com/sirupsen/logrus
   misspell:
     locale: US
   lll:
     line-length: 180
   goimports:
-    local-prefixes: github.com/golangci/golangci-lint
+    local-prefixes: github.com/aslakknutsen/istio-workspace
   gocritic:
     enabled-tags:
       - performance
@@ -34,11 +33,13 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - maligned
-    - prealloc
-    - gochecknoglobals
+    - gochecknoinits # both Cobra and k8s/istio generated APIs are using init()
+    - gochecknoglobals # TODO discuss
+run:
+  skip-dirs:
+    - ./pkg/apis/istio
 
 service:
-  project-path: github.com/arquillian/ike-prow-plugins
+  project-path: github.com/aslakknutsen/istio-workspace
   prepare:
-    - make tools deps generate
+    - make tools deps codegen

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:315ee4e58738f41b338a701e8acb4e991f6d30737c2ae757d2087a1d28d72810"
-  name = "cloud.google.com/go"
-  packages = ["compute/metadata"]
-  pruneopts = "NT"
-  revision = "28a4bc8c44b3acbcc482cff0cdf7de29a4688b61"
-  version = "v0.35.1"
-
-[[projects]]
   digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
@@ -433,10 +425,7 @@
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "google",
     "internal",
-    "jws",
-    "jwt",
   ]
   pruneopts = "NT"
   revision = "99b60b757ec124ebb7d6b7e97f153b19c10ce163"
@@ -509,13 +498,10 @@
   digest = "1:902ffa11f1d8c19c12b05cabffe69e1a16608ad03a8899ebcb9c6bde295660ae"
   name = "google.golang.org/appengine"
   packages = [
-    ".",
     "internal",
-    "internal/app_identity",
     "internal/base",
     "internal/datastore",
     "internal/log",
-    "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
     "urlfetch",
@@ -542,7 +528,7 @@
 
 [[projects]]
   branch = "istio-8772"
-  digest = "1:9cda24439cc6f1714c38821fc80f644f6378993831a4f632c929b384264ba38b"
+  digest = "1:3edc7a21c06a0ef5765a011f302027ca2d9ff93e32b6b53e8ea52fa777be7492"
   name = "istio.io/api"
   packages = [
     "networking/v1alpha3",
@@ -689,11 +675,9 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
-    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
     "restmapper",
-    "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
     "tools/clientcmd",
@@ -713,7 +697,6 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/jsonpath",
     "util/retry",
     "util/workqueue",
   ]
@@ -849,7 +832,6 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
-    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -37,7 +37,7 @@ var developCmd = &cobra.Command{
 	Use:   "develop",
 	Short: "starts the development flow",
 	Long:  `TODO`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 
 		if !telepresenceExists() {
 			os.Exit(1)

--- a/cmd/ike/cmd/root.go
+++ b/cmd/ike/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/spf13/cobra"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
@@ -73,13 +72,13 @@ func startOperator() {
 	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+	if err = apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err = controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/cmd/ike/cmd/root.go
+++ b/cmd/ike/cmd/root.go
@@ -30,7 +30,7 @@ Aliquam vitae dolor neque. Aliquam facilisis posuere nulla sit amet porttitor.
 
 Duis nec interdum velit, id consectetur erat. In tempor tempor turpis vel rhoncus.`,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 		printVersion()
 		startOperator()
 	},

--- a/cmd/ike/cmd/version.go
+++ b/cmd/ike/cmd/version.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/aslakknutsen/istio-workspace/version"
+
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/cobra"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"

--- a/cmd/ike/cmd/version.go
+++ b/cmd/ike/cmd/version.go
@@ -21,7 +21,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version number of ike cli",
 	Long:  `All software has versions. This is Ike's`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 		printVersion()
 	},
 }

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/aslakknutsen/istio-workspace/cmd/ike/cmd"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -92,7 +92,7 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	err = r.client.Get(ctx, types.NamespacedName{Namespace: request.Namespace, Name: instance.Spec.Ref}, &deployment)
 	if err != nil {
-		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
+		updateStatus(ctx, reqLogger, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
 
@@ -101,7 +101,7 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	serviceList := corev1.ServiceList{}
 	err = r.client.List(ctx, &client.ListOptions{Namespace: request.Namespace}, &serviceList)
 	if err != nil {
-		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
+		updateStatus(ctx, reqLogger, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
 	for i := range serviceList.Items {
@@ -112,7 +112,7 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	drList := istionetwork.DestinationRuleList{}
 	err = r.client.List(ctx, &client.ListOptions{Namespace: request.Namespace}, &drList)
 	if err != nil {
-		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
+		updateStatus(ctx, reqLogger, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
 	for i := range drList.Items {
@@ -123,19 +123,19 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	vsList := istionetwork.VirtualServiceList{}
 	err = r.client.List(ctx, &client.ListOptions{Namespace: request.Namespace}, &vsList)
 	if err != nil {
-		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
+		updateStatus(ctx, reqLogger, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
 	for i := range vsList.Items {
 		vs := &vsList.Items[i]
 		reqLogger.Info("Found VirtualService", "name", vs.ObjectMeta.Name)
 	}
-	updateStatus(reqLogger, ctx, r.client, instance, "success")
+	updateStatus(ctx, reqLogger, r.client, instance, "success")
 
 	return reconcile.Result{}, nil
 }
 
-func updateStatus(log logr.Logger, ctx context.Context, c client.Client, session *istiov1alpha1.Session, state string) {
+func updateStatus(ctx context.Context, log logr.Logger, c client.Client, session *istiov1alpha1.Session, state string) {
 	session.Status = istiov1alpha1.SessionStatus{
 		State: &state,
 	}

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -135,7 +135,7 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 	return reconcile.Result{}, nil
 }
 
-func updateStatus(ctx context.Context, log logr.Logger, c client.Client, session *istiov1alpha1.Session, state string) {
+func updateStatus(ctx context.Context, log logr.Logger, c client.StatusClient, session *istiov1alpha1.Session, state string) {
 	session.Status = istiov1alpha1.SessionStatus{
 		State: &state,
 	}

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -104,7 +104,8 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
-	for _, vs := range serviceList.Items {
+	for i := range serviceList.Items {
+		vs := &serviceList.Items[i]
 		reqLogger.Info("Found Service", "name", vs.ObjectMeta.Name, "labels", vs.Labels)
 	}
 
@@ -114,7 +115,8 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
-	for _, vs := range drList.Items {
+	for i := range drList.Items {
+		vs := &drList.Items[i]
 		reqLogger.Info("Found DestinationRule", "name", vs.ObjectMeta.Name)
 	}
 
@@ -124,7 +126,8 @@ func (r *ReconcileSession) Reconcile(request reconcile.Request) (reconcile.Resul
 		updateStatus(reqLogger, ctx, r.client, instance, fmt.Sprintf("%v", err))
 		return reconcile.Result{Requeue: false}, err
 	}
-	for _, vs := range vsList.Items {
+	for i := range vsList.Items {
+		vs := &vsList.Items[i]
 		reqLogger.Info("Found VirtualService", "name", vs.ObjectMeta.Name)
 	}
 	updateStatus(reqLogger, ctx, r.client, instance, "success")

--- a/pkg/controller/session/session_controller.go
+++ b/pkg/controller/session/session_controller.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	istionetwork "github.com/aslakknutsen/istio-workspace/pkg/apis/istio/networking/v1alpha3"
 	istiov1alpha1 "github.com/aslakknutsen/istio-workspace/pkg/apis/istio/v1alpha1"
 
-	istionetwork "github.com/aslakknutsen/istio-workspace/pkg/apis/istio/networking/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 


### PR DESCRIPTION
#### Noteworthy settings

* disallows usage of `github.com/sirupsen/logrus` in favor of `sigs.k8s.io/controller-runtime/pkg/runtime/log`
* disables `gochecknoinits` as both Cobra and operator-sdk relies on
that
* skips autogenerated `./pkg/apis/istio` sources
* disables [gochecknoglobals](https://github.com/leighmcculloch/gochecknoglobals) - probably we should discuss that though

And fixes a bunch of findings too (see commits).

#### Open points

Currently, this runs as part of the default target, so the errors will be caught while running travis build. Ideally, we should move that away to dedicated service - https://golangci.com/. Once we find the final home for this work let's make that happen. WDYT?