### PR TITLE
chore(cmd): cleans up cobra flags

### DIFF
--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -36,19 +36,15 @@ const telepresenceBin = "telepresence"
 var developCmd = &cobra.Command{
 	Use:   "develop",
 	Short: "starts the development flow",
-	Long:  `TODO`,
-	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
-
+	PreRun: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 		if !telepresenceExists() {
 			os.Exit(1)
 		}
-
+	},
+	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 		var tp = exec.Command(telepresenceBin, parseArguments()...)
-
 		redirectStreams(tp)
-
 		err := tp.Wait()
-
 		if err != nil {
 			log.Error(err, fmt.Sprintf("%s failed", telepresenceBin))
 			os.Exit(1)

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -21,13 +21,13 @@ var (
 )
 
 func init() {
-	developCmd.PersistentFlags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
-	developCmd.PersistentFlags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
-	developCmd.PersistentFlags().StringVarP(&runnable, "run", "r", "", "command to run your application")
-	developCmd.PersistentFlags().StringVarP(&method, "method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
+	developCmd.Flags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
+	developCmd.Flags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
+	developCmd.Flags().StringVarP(&runnable, "run", "r", "", "command to run your application")
+	developCmd.Flags().StringVarP(&method, "method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
 
-	_ = developCmd.MarkPersistentFlagRequired("deployment")
-	_ = developCmd.MarkPersistentFlagRequired("run")
+	_ = developCmd.MarkFlagRequired("deployment")
+	_ = developCmd.MarkFlagRequired("run")
 	rootCmd.AddCommand(developCmd)
 }
 

--- a/cmd/ike/cmd/root.go
+++ b/cmd/ike/cmd/root.go
@@ -25,11 +25,6 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "ike",
 	Short: "ike lets you safely develop and test on prod without a sweat",
-	Long: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-Aliquam vitae dolor neque. Aliquam facilisis posuere nulla sit amet porttitor. 
-
-Duis nec interdum velit, id consectetur erat. In tempor tempor turpis vel rhoncus.`,
-
 	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 		printVersion()
 		startOperator()


### PR DESCRIPTION
* chore(flags): makes flags local for `develop` command - we don't need them persistent as there is no subcommand which would need those values
* chore(cmd): checks tp cmd existence in pre-run hook instead