### PR TITLE
feat(config): introduces configuration complementary to flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Test results
+*ginkgo-test-results.xml
 
 # Temporary Files
 bin/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -999,6 +999,7 @@
   input-imports = [
     "github.com/go-logr/logr",
     "github.com/onsi/ginkgo",
+    "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,6 +66,14 @@
   version = "v2.8.1"
 
 [[projects]]
+  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   branch = "master"
   digest = "1:d421af4c4fe51d399667d573982d663fe1fa67020a88d3ae43466ebfe8e2b5c9"
   name = "github.com/go-logr/logr"
@@ -207,6 +215,39 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:62ba88d64dabadbbad170cf6b0d3bfd1f50c36b1566583a28d99304eb08a9bd2"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "NT"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:76efa3b55850d9caa14f8c0b3a951797f9bc2ffc283526073dcad1b06b6e02d3"
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile",
+  ]
+  pruneopts = "NT"
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:aaa38889f11896ee3644d77e17dc7764cc47f5f3d3b488268df2af2b52541c5f"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -231,6 +272,14 @@
   version = "v1.1.5"
 
 [[projects]]
+  digest = "1:4244266b65ea535b8ebd109a327720821707b59f9a37bda738946d52ec69442d"
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
   branch = "master"
   digest = "1:7d9fcac7f1228470c4ea0ee31cdfb662a758c44df691e39b3e76c11d3e12ba8f"
   name = "github.com/mailru/easyjson"
@@ -251,6 +300,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:a45ae66dea4c899d79fceb116accfa1892105c251f0dcd9a217ddc276b42ec68"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
+
+[[projects]]
   digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -265,6 +322,54 @@
   pruneopts = "NT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
+
+[[projects]]
+  digest = "1:0204417af2b5c56719f7e2809902c9a56ebb1b539d73ba520eeac84e98f21b72"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types",
+  ]
+  pruneopts = "NT"
+  revision = "2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f"
+  version = "v1.7.0"
+
+[[projects]]
+  digest = "1:7efa6868c0394e8567b411d9160f10376d6f28926c5786d520f3603bc3e18198"
+  name = "github.com/onsi/gomega"
+  packages = [
+    ".",
+    "format",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types",
+  ]
+  pruneopts = "NT"
+  revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
+  version = "v1.4.3"
 
 [[projects]]
   branch = "master"
@@ -287,6 +392,14 @@
   pruneopts = "NT"
   revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
   version = "v1.2"
+
+[[projects]]
+  digest = "1:1a6e99fe61e963dce0dd87a0856fcfcc1c286db3eba388dd77335aa4ac5623b3"
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -350,6 +463,25 @@
   revision = "316cf8ccfec56d206735d46333ca162eb374da8b"
 
 [[projects]]
+  digest = "1:1bc08ec221c4fb25e6f2c019b23fe989fb44573c696983d8e403a3b76cc378e1"
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = "NT"
+  revision = "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5"
+  version = "v1.2.1"
+
+[[projects]]
+  digest = "1:c5e6b121ef3d2043505edaf4c80e5a008cec2513dc8804795eb0479d1555bcf7"
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:234b95cdbb31612ff4f97e0ac69abdede0c60f5f84e5d3f40123859f77d8bc2c"
   name = "github.com/spf13/cobra"
   packages = ["."]
@@ -358,12 +490,28 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:f29f83301ed096daed24a90f4af591b7560cb14b9cc3e1827abbf04db7269ab5"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "NT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:958dd1902c8999769574c48476f471791be450a2aacaa2c411c408d22ec84e80"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
+  version = "v1.3.1"
 
 [[projects]]
   digest = "1:22f696cee54865fb8e9ff91df7b633f6b8f22037a8015253c6b6a71ca82219c7"
@@ -411,6 +559,9 @@
   packages = [
     "context",
     "context/ctxhttp",
+    "html",
+    "html/atom",
+    "html/charset",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -447,12 +598,24 @@
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -511,12 +674,29 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "https://github.com/fsnotify/fsnotify.git"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
   pruneopts = "NT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  branch = "v1"
+  digest = "1:8fb1ccb16a6cfecbfdfeb84d8ea1cc7afa8f9ef16526bc2326f72d993e32cef1"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
@@ -818,12 +998,17 @@
   analyzer-version = 1
   input-imports = [
     "github.com/go-logr/logr",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/metrics",
     "github.com/operator-framework/operator-sdk/pkg/predicate",
     "github.com/operator-framework/operator-sdk/version",
+    "github.com/spf13/afero",
     "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
+    "github.com/spf13/viper",
     "istio.io/api/networking/v1alpha3",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,7 +73,8 @@ required = [
   name = "github.com/onsi/ginkgo"
   version = "1.7.0"
 
-# Apply workaround from https://github.com/golang/dep/issues/1799
+# Workaround for https://github.com/golang/dep/issues/1799
+# Otherwise ginkgo/gomega won't be pulled in
 [[override]]
   name = "gopkg.in/fsnotify.v1"
   source = "https://github.com/fsnotify/fsnotify.git"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,6 +9,14 @@ required = [
   "k8s.io/gengo/args",
 ]
 
+[prune]
+  go-tests = true
+  non-go = true
+
+  [[prune.project]]
+    name = "k8s.io/code-generator"
+    non-go = false
+
 [[override]]
   name = "k8s.io/code-generator"
   # revision for tag "kubernetes-1.13.1"
@@ -57,10 +65,15 @@ required = [
   name = "k8s.io/kube-openapi"
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
-[prune]
-  go-tests = true
-  non-go = true
+[[constraint]]
+  name = "github.com/onsi/gomega"
+  version = "1.4.3"
 
-  [[prune.project]]
-    name = "k8s.io/code-generator"
-    non-go = false
+[[constraint]]
+  name = "github.com/onsi/ginkgo"
+  version = "1.7.0"
+
+# Apply workaround from https://github.com/golang/dep/issues/1799
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"

--- a/cmd/ike/cmd/cmd_suite_test.go
+++ b/cmd/ike/cmd/cmd_suite_test.go
@@ -1,0 +1,13 @@
+package cmd_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cmd Suite")
+}

--- a/cmd/ike/cmd/cmd_suite_test.go
+++ b/cmd/ike/cmd/cmd_suite_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	. "github.com/aslakknutsen/istio-workspace/test"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -9,5 +10,5 @@ import (
 
 func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cmd Suite")
+	RunSpecWithJUnitReporter(t, "CLI Suite")
 }

--- a/cmd/ike/cmd/cmd_suite_test.go
+++ b/cmd/ike/cmd/cmd_suite_test.go
@@ -1,8 +1,9 @@
 package cmd_test
 
 import (
-	. "github.com/aslakknutsen/istio-workspace/test"
 	"testing"
+
+	. "github.com/aslakknutsen/istio-workspace/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -22,14 +22,16 @@ func NewDevelopCmd() *cobra.Command {
 		Use:   "develop",
 		Short: "starts the development flow",
 
-		PreRun: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
+		PreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 			if !telepresenceExists() {
-				os.Exit(1)
+				return fmt.Errorf("unable to find %s on your $PATH", telepresenceBin)
 			}
 			config.SyncFlag(cmd, "deployment")
 			config.SyncFlag(cmd, "run")
 			config.SyncFlag(cmd, "port")
 			config.SyncFlag(cmd, "method")
+
+			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
 			var tp = exec.Command(telepresenceBin, parseArguments(cmd)...)

--- a/cmd/ike/cmd/develop.go
+++ b/cmd/ike/cmd/develop.go
@@ -6,51 +6,53 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/aslakknutsen/istio-workspace/cmd/ike/config"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	deploymentName string
-	port           int
-	runnable       string
-	method         string
-)
+const telepresenceBin = "telepresence"
 
-func init() {
-	developCmd.Flags().StringVarP(&deploymentName, "deployment", "d", "", "name of the deployment or deployment config")
-	developCmd.Flags().IntVarP(&port, "port", "p", 8000, "port to be exposed")
-	developCmd.Flags().StringVarP(&runnable, "run", "r", "", "command to run your application")
-	developCmd.Flags().StringVarP(&method, "method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
+func NewDevelopCmd() *cobra.Command {
+
+	developCmd := &cobra.Command{
+		Use:   "develop",
+		Short: "starts the development flow",
+
+		PreRun: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
+			if !telepresenceExists() {
+				os.Exit(1)
+			}
+			config.SyncFlag(cmd, "deployment")
+			config.SyncFlag(cmd, "run")
+			config.SyncFlag(cmd, "port")
+			config.SyncFlag(cmd, "method")
+		},
+		Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
+			var tp = exec.Command(telepresenceBin, parseArguments(cmd)...)
+			redirectStreams(tp)
+			err := tp.Wait()
+			if err != nil {
+				log.Error(err, fmt.Sprintf("%s failed", telepresenceBin))
+				os.Exit(1)
+			}
+		},
+	}
+
+	developCmd.Flags().StringP("deployment", "d", "", "name of the deployment or deployment config")
+	developCmd.Flags().IntP("port", "p", 8000, "port to be exposed")
+	developCmd.Flags().StringP("run", "r", "", "command to run your application")
+	developCmd.Flags().StringP("method", "m", "inject-tcp", "telepresence proxying mode - see https://www.telepresence.io/reference/methods")
+
+	developCmd.Flags().VisitAll(config.BindFullyQualifiedFlag(developCmd))
 
 	_ = developCmd.MarkFlagRequired("deployment")
 	_ = developCmd.MarkFlagRequired("run")
-	rootCmd.AddCommand(developCmd)
-}
 
-const telepresenceBin = "telepresence"
-
-var developCmd = &cobra.Command{
-	Use:   "develop",
-	Short: "starts the development flow",
-	PreRun: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
-		if !telepresenceExists() {
-			os.Exit(1)
-		}
-	},
-	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
-		var tp = exec.Command(telepresenceBin, parseArguments()...)
-		redirectStreams(tp)
-		err := tp.Wait()
-		if err != nil {
-			log.Error(err, fmt.Sprintf("%s failed", telepresenceBin))
-			os.Exit(1)
-		}
-
-	},
+	return developCmd
 }
 
 func redirectStreams(command *exec.Cmd) {
@@ -83,12 +85,13 @@ func redirectStreams(command *exec.Cmd) {
 	wg.Wait()
 }
 
-func parseArguments() []string {
-	runArgs := strings.Split(runnable, " ")
+func parseArguments(cmd *cobra.Command) []string {
+	run, _ := cmd.Flags().GetString("run")
+	runArgs := strings.Split(run, " ")
 	return append([]string{
-		"--swap-deployment", deploymentName,
-		"--expose", strconv.Itoa(port),
-		"--method", method,
+		"--swap-deployment", cmd.Flag("deployment").Value.String(),
+		"--expose", cmd.Flag("port").Value.String(),
+		"--method", cmd.Flag("method").Value.String(),
 		"--run"}, runArgs...)
 }
 

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -74,6 +74,13 @@ var _ = Describe("Usage of ike develop command", func() {
 			CleanUp(GinkgoT())
 		})
 
+		It("should fail when passing non-existing config file", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--config", "~/test.yaml")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`Config File "test" Not Found`))
+		})
+
 		It("should load deployment from config file if not passed as flag", func() {
 			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234", "--config", configFile.Name())
 

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -74,14 +74,14 @@ var _ = Describe("Usage of ike develop command", func() {
 			CleanUp(GinkgoT())
 		})
 
-		It("load deployment from config file if not passed as flag", func() {
+		It("should load deployment from config file if not passed as flag", func() {
 			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234", "--config", configFile.Name())
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(developCmd.Flag("deployment").Value.String()).To(Equal("test"))
 		})
 
-		It("use run defined in flag not from config file", func() {
+		It("should use run defined in the flag not from config file", func() {
 			_, err := ValidateArgumentsOf(developCmd).Passing("-r", "'./test.sh'", "--config", configFile.Name())
 
 			Expect(err).ToNot(HaveOccurred())
@@ -101,7 +101,7 @@ var _ = Describe("Usage of ike develop command", func() {
 				_ = os.Setenv("IKE_DEVELOP_PORT", oldEnv)
 			})
 
-			It("should use environment variable over config", func() {
+			It("should use environment variable over config file", func() {
 				_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())
 
 				Expect(err).ToNot(HaveOccurred())

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Usage of ike develop command", func() {
 
 	})
 
-	XContext("with config file", func() {
+	Context("with config file", func() {
 
 		const config = `develop:
   deployment: test

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -1,0 +1,122 @@
+package cmd_test
+
+import (
+	"os"
+
+	. "github.com/aslakknutsen/istio-workspace/cmd/ike/cmd"
+
+	. "github.com/aslakknutsen/istio-workspace/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("Usage of ike develop command", func() {
+
+	var developCmd *cobra.Command
+
+	BeforeEach(func() {
+		developCmd = NewDevelopCmd()
+		developCmd.SilenceUsage = true
+		developCmd.SilenceErrors = true
+		NewRootCmd().AddCommand(developCmd)
+	})
+
+	Context("with flags only", func() {
+
+		It("should fail when deployment is not specified", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("deployment")))
+		})
+
+		It("should fail when run command is not specified", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("run")))
+		})
+
+		It("should have default port 8000 when flag not specified", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(developCmd.Flag("port").Value.String()).To(Equal("8000"))
+		})
+
+		It("should have default method inject-tcp when flag not specified", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(developCmd.Flag("method").Value.String()).To(Equal("inject-tcp"))
+		})
+
+	})
+
+	Context("with config file", func() {
+
+		const config = `develop:
+  deployment: test
+  run: "python3 server.py"
+  port: 5555
+`
+		var configFile afero.File
+
+		BeforeEach(func() {
+			configFile = TmpFile(GinkgoT(), "config.yaml", config)
+		})
+
+		AfterEach(func() {
+			CleanUp(GinkgoT())
+		})
+
+		It("load deployment from config file if not passed as flag", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234", "--config", configFile.Name())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(developCmd.Flag("deployment").Value.String()).To(Equal("test"))
+		})
+
+		It("use run defined in flag not from config file", func() {
+			_, err := ValidateArgumentsOf(developCmd).Passing("-r", "'./test.sh'", "--config", configFile.Name())
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(developCmd.Flag("run").Value.String()).To(Equal(`'./test.sh'`))
+		})
+
+		Context("with ENV port variable", func() {
+
+			var oldEnv string
+
+			BeforeEach(func() {
+				oldEnv = os.Getenv("IKE_DEVELOP_PORT")
+				_ = os.Setenv("IKE_DEVELOP_PORT", "4321")
+			})
+
+			AfterEach(func() {
+				_ = os.Setenv("IKE_DEVELOP_PORT", oldEnv)
+			})
+
+			It("should use environment variable over config", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(developCmd.Flag("port").Value.String()).To(Equal("4321"))
+			})
+
+			It("should use flag over environment variable", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1111", "--config", configFile.Name())
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(developCmd.Flag("port").Value.String()).To(Equal("1111"))
+			})
+
+		})
+
+	})
+
+})

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Usage of ike develop command", func() {
 
 	BeforeEach(func() {
 		developCmd = NewDevelopCmd()
-		developCmd.SilenceUsage = true
-		developCmd.SilenceErrors = true
+		developCmd.SilenceUsage = false
+		developCmd.SilenceErrors = false
 		NewRootCmd().AddCommand(developCmd)
 	})
 

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var _ = Describe("Usage of ike develop command", func() {
+var _ = XDescribe("Usage of ike develop command", func() {
 
 	var developCmd *cobra.Command
 

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Usage of ike develop command", func() {
 
 	BeforeEach(func() {
 		developCmd = NewDevelopCmd()
-		developCmd.SilenceUsage = false
-		developCmd.SilenceErrors = false
+		developCmd.SilenceUsage = true
+		developCmd.SilenceErrors = true
 		NewRootCmd().AddCommand(developCmd)
 	})
 

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var _ = XDescribe("Usage of ike develop command", func() {
+var _ = Describe("Usage of ike develop command", func() {
 
 	var developCmd *cobra.Command
 
@@ -57,7 +57,7 @@ var _ = XDescribe("Usage of ike develop command", func() {
 
 	})
 
-	Context("with config file", func() {
+	XContext("with config file", func() {
 
 		const config = `develop:
   deployment: test

--- a/cmd/ike/cmd/version.go
+++ b/cmd/ike/cmd/version.go
@@ -13,11 +13,7 @@ import (
 
 var log = logf.Log.WithName("cmd")
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
-var versionCmd = &cobra.Command{
+var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version number of ike cli",
 	Long:  `All software has versions. This is Ike's`,

--- a/cmd/ike/config/config.go
+++ b/cmd/ike/config/config.go
@@ -29,9 +29,11 @@ func SetupConfigSources(configFile string, notDefault bool) error {
 
 	if err := viper.ReadInConfig(); err != nil {
 		if notDefault {
-			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-				return err
-			}
+			return err
+		}
+
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
 		}
 	}
 	return nil

--- a/cmd/ike/config/config.go
+++ b/cmd/ike/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// SetupConfigSources sets up Viper configuration. If specific file path is provided but fails when loading it will
+// return an error. In case of default config location it will not fail if file does not exist, but will in any other
+// case.
+func SetupConfigSources(configFile string, notDefault bool) error {
+	viper.SetEnvPrefix("IKE")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetTypeByDefaultValue(true)
+
+	ext := path.Ext(configFile)
+	viper.SetConfigName(strings.TrimSuffix(path.Base(configFile), ext))
+	if !contains(SupportedExtensions(), strings.TrimPrefix(path.Ext(ext), ".")) {
+		return fmt.Errorf("'%s' extension is not supported. Use one of [%s]", ext, strings.Join(SupportedExtensions(), ", "))
+	}
+	viper.SetConfigType(ext[1:])
+	viper.AddConfigPath(path.Dir(configFile))
+
+	if err := viper.ReadInConfig(); err != nil {
+		if notDefault {
+			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// SupportedExtensions returns a slice of all supported config format (as file extensions)
+func SupportedExtensions() []string {
+	return viper.SupportedExts
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// SyncFlag ensures that if configuration provides a value for a given cmd.flag it will be set back to the flag itself.
+// This way we can make flags required but still have their values provided by the configuration source
+func SyncFlag(cmd *cobra.Command, flagName string) {
+	value := viper.GetString(cmd.Name() + "." + flagName)
+	if value != "" {
+		_ = cmd.Flags().Set(flagName, value)
+	}
+}
+
+// BindFullyQualifiedFlag ensures that each flag used in commands is bound to a key using fully qualified name
+// which has a following form:
+//
+// 		commandName.flagName
+//
+// This lets us  keep structure of yaml file:
+//
+//	commandName:
+//		flagName: value
+func BindFullyQualifiedFlag(cmd *cobra.Command) func(flag *pflag.Flag) {
+	return func(flag *pflag.Flag) {
+		_ = viper.BindPFlag(cmd.Name()+"."+flag.Name, flag)
+	}
+}

--- a/cmd/ike/main.go
+++ b/cmd/ike/main.go
@@ -13,5 +13,7 @@ func main() {
 	// uniform and structured logs.
 	logf.SetLogger(logf.ZapLogger(false))
 
-	cmd.Execute()
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.AddCommand(cmd.VersionCmd, cmd.NewDevelopCmd())
+	_ = rootCmd.Execute()
 }

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -17,7 +17,9 @@ func ValidateArgumentsOf(command *cobra.Command) *Cmd {
 
 func (command *Cmd) Passing(args ...string) (output string, err error) {
 	cmd := (*cobra.Command)(command)
-	return executeCommand(cmd, args...)
+	output, err = executeCommand(cmd, args...)
+	println(output)
+	return output, err
 }
 
 func executeCommand(cmd *cobra.Command, args ...string) (output string, err error) {

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type Cmd cobra.Command
+
+// ValidateArgumentsOf will not run actual command but let the initialization and validation happen
+func ValidateArgumentsOf(command *cobra.Command) *Cmd {
+	fmt.Print("$ ")
+	command.Run = emptyRun
+	return (*Cmd)(command)
+}
+
+func (command *Cmd) Passing(args ...string) (output string, err error) {
+	cmd := (*cobra.Command)(command)
+	fmt.Println(cmd.CommandPath() + " " + strings.Join(args, " "))
+	return executeCommand(cmd, args...)
+}
+
+func executeCommand(cmd *cobra.Command, args ...string) (output string, err error) {
+	_, output, err = executeCommandC(cmd, args...)
+	return output, err
+}
+
+func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, output string, err error) {
+	buf := new(bytes.Buffer)
+	cmd.SetOutput(buf)
+	cmd.Root().SetArgs(append(strings.Split(cmd.CommandPath(), " ")[1:], args...))
+	c, err = cmd.ExecuteC()
+	return c, buf.String(), err
+}
+
+func emptyRun(cmd *cobra.Command, args []string) {}

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,14 +11,12 @@ type Cmd cobra.Command
 
 // ValidateArgumentsOf will not run actual command but let the initialization and validation happen
 func ValidateArgumentsOf(command *cobra.Command) *Cmd {
-	fmt.Print("$ ")
 	command.Run = emptyRun
 	return (*Cmd)(command)
 }
 
 func (command *Cmd) Passing(args ...string) (output string, err error) {
 	cmd := (*cobra.Command)(command)
-	fmt.Println(cmd.CommandPath() + " " + strings.Join(args, " "))
 	return executeCommand(cmd, args...)
 }
 

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -18,7 +18,6 @@ func ValidateArgumentsOf(command *cobra.Command) *Cmd {
 func (command *Cmd) Passing(args ...string) (output string, err error) {
 	cmd := (*cobra.Command)(command)
 	output, err = executeCommand(cmd, args...)
-	println(output)
 	return output, err
 }
 

--- a/test/ginkgo_custom_reporter.go
+++ b/test/ginkgo_custom_reporter.go
@@ -1,0 +1,14 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+)
+
+// RunSpecWithJUnitReporter calls custom ginkgo junit reporter
+func RunSpecWithJUnitReporter(t *testing.T, description string) {
+	junitReporter := reporters.NewJUnitReporter("ginkgo-test-results.xml")
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, description, []ginkgo.Reporter{junitReporter})
+}

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -1,0 +1,74 @@
+package test
+
+//  Based on https://github.com/Flaque/filet
+//  We might want to switch to upstream when https://github.com/Flaque/filet/pull/2 gets merged
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/afero"
+)
+
+// TestReporter can be used to report test failures. It is satisfied by the standard library's *testing.T.
+type TestReporter interface { //nolint[:golint]
+	Errorf(format string, args ...interface{})
+}
+
+// Files keeps track of files that we've used so we can clean up.
+var Files []string
+var appFs = afero.NewOsFs()
+
+// TmpFile Creates a specified file for us to use when testing
+func TmpFile(t TestReporter, fileName, content string) afero.File {
+	filePath := fmt.Sprintf("%s/%s/%s", os.TempDir(), randomAlphaNumeric(), fileName)
+
+	if err := appFs.MkdirAll(path.Dir(filePath), os.ModePerm); err != nil {
+		t.Errorf("Failed to create the file: %s. Reason: %s", filePath, err)
+		return nil
+	}
+
+	file, err := appFs.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Errorf("Failed to create the file: %s. Reason: %s", filePath, err)
+		return nil
+	}
+
+	if _, err := file.WriteString(content); err != nil {
+		t.Errorf("Failed writing to a file")
+		return nil
+	}
+	Files = append(Files, file.Name())
+
+	return file
+}
+
+// CleanUp removes all files in our test registry and calls `t.Error` if something goes wrong.
+func CleanUp(t TestReporter) {
+	for _, filePath := range Files {
+		if err := appFs.RemoveAll(filePath); err != nil {
+			t.Errorf(appFs.Name(), err)
+		}
+	}
+
+	Files = make([]string, 0)
+}
+
+// Exists returns true if the file exists. Calls t.Error if something goes wrong while checking.
+func Exists(t TestReporter, filePath string) bool {
+	exists, err := afero.Exists(appFs, filePath)
+	if err != nil {
+		t.Errorf("Something went wrong when checking if %s exists! Reason: %s", filePath, err)
+	}
+	return exists
+}
+
+func randomAlphaNumeric() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	s := hex.EncodeToString(b)
+	return s
+}

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -31,7 +31,7 @@ func TmpFile(t TestReporter, fileName, content string) afero.File {
 		return nil
 	}
 
-	file, err := appFs.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0600)
+	file, err := appFs.OpenFile(filePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
 	if err != nil {
 		t.Errorf("Failed to create the file: %s. Reason: %s", filePath, err)
 		return nil


### PR DESCRIPTION
### Changes in this PR

  * external config sources based on [viper](https://github.com/spf13/viper) (in order of importance)
    * flags
    * env variables
    * config file
  * test setup based on [ginkgo](https://github.com/spf13/viper)
  * refactored commands to not be singletons
  * introduces `config` packages which wraps viper
    * centralized settings
    * keeping config and flags in sync (so we still can use required flag validation)

### Rationale

Common settings, such as `run` and `build` recipes, could be shared in the repo as a config file rather than being used constantly from the CLI

Fixes #12