### PR TITLE
chore(make): removes tools from the default target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - "1.11.4"
 
 install:
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - make tools
 
 go_import_path: github.com/aslakknutsen/istio-workspace

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ define header =
 endef
 
 .PHONY: all
-all: tools deps format lint compile ## (default) Runs 'tools deps format lint compile' targets
+all: deps format lint compile ## (default) Runs 'deps format lint compile' targets
 
 .PHONY: help
 help:
@@ -34,6 +34,7 @@ format: ## Removes unneeded imports and formats source code
 .PHONY: tools
 tools: ## Installs required go tools
 	$(call header,"Installing required tools")
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
There's no need to install project tools every time when you run `make` (default target). It's one-off operation when setting up the project or running CI job.

In addition `dep` installation is added to `tools` target so setup is self-contained.