### PR TITLE
chore(errors): cmds to return errors instead of exiting

### DIFF
--- a/cmd/ike/cmd/root.go
+++ b/cmd/ike/cmd/root.go
@@ -28,8 +28,9 @@ func NewRootCmd() *cobra.Command {
 	var configFile string
 
 	rootCmd := &cobra.Command{
-		Use:   "ike",
-		Short: "ike lets you safely develop and test on prod without a sweat",
+		Use:          "ike",
+		Short:        "ike lets you safely develop and test on prod without a sweat",
+		SilenceUsage: true,
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 			return config.SetupConfigSources(configFile, cmd.Flag("config").Changed)

--- a/cmd/ike/cmd/version.go
+++ b/cmd/ike/cmd/version.go
@@ -17,8 +17,9 @@ var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version number of ike cli",
 	Long:  `All software has versions. This is Ike's`,
-	Run: func(cmd *cobra.Command, args []string) { //nolint[:unparam]
+	RunE: func(cmd *cobra.Command, args []string) error { //nolint[:unparam]
 		printVersion()
+		return nil
 	},
 }
 

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -12,6 +12,7 @@ type Cmd cobra.Command
 // ValidateArgumentsOf will not run actual command but let the initialization and validation happen
 func ValidateArgumentsOf(command *cobra.Command) *Cmd {
 	command.Run = emptyRun
+	command.RunE = emptyRunE
 	return (*Cmd)(command)
 }
 
@@ -35,3 +36,7 @@ func executeCommandC(cmd *cobra.Command, args ...string) (c *cobra.Command, outp
 }
 
 func emptyRun(cmd *cobra.Command, args []string) {}
+
+func emptyRunE(cmd *cobra.Command, args []string) error {
+	return nil
+}


### PR DESCRIPTION
Instead of using `Run` and regular Cobra hooks, let's start using `RunE` and alike to return errors instead of calling `os.Exit` and let Cobra handle that instead.

This gives us the immediate benefit of better testability - as there's no `os.Exit` in the code under test, there is no risk in abruptly finishing test suite for example.

#### Open Question

As-is Cobra will print the usage of the cmd in case of failure. This can be easily disabled by setting `SilenceUsage` flag to `false`. Shall we consider that change too? @aslakknutsen 