### PR TITLE
 fix(config): flags take precedence over other config sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ compile: codegen test $(BINARY_DIR)/$(BINARY_NAME) ## Compiles binaries
 .PHONY: test ## Runs tests
 test:
 	$(call header,"Running tests")
-	ginkgo -r
+	ginkgo -r -v
 
 .PHONY: clean
 clean: ## Removes build artifacts

--- a/cmd/ike/config/config.go
+++ b/cmd/ike/config/config.go
@@ -14,6 +14,7 @@ import (
 // return an error. In case of default config location it will not fail if file does not exist, but will in any other
 // case.
 func SetupConfigSources(configFile string, notDefault bool) error {
+	viper.Reset()
 	viper.SetEnvPrefix("IKE")
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -53,11 +54,13 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-// SyncFlag ensures that if configuration provides a value for a given cmd.flag it will be set back to the flag itself.
+// SyncFlag ensures that if configuration provides a value for a given cmd.flag it will be set back to the flag itself,
+// but only if the flag was not set through CLI.
+//
 // This way we can make flags required but still have their values provided by the configuration source
 func SyncFlag(cmd *cobra.Command, flagName string) {
 	value := viper.GetString(cmd.Name() + "." + flagName)
-	if value != "" {
+	if value != "" && !cmd.Flag(flagName).Changed {
 		_ = cmd.Flags().Set(flagName, value)
 	}
 }


### PR DESCRIPTION
Fixes #26 

#### In addition 

* calls `viper.Reset()` when setting up configuration for the command, so tests don't rely on global state. As long as we have a single process (cli) that is fine, but not the ideal solution though - I will think of something better here as it makes testing somewhat brittle.
* redirects outputs to `cobra` command buffers instead - this way we can inspect it while testing (by default it's `Stdout` and `Stderr`)
* runs `ginkgo` in the verbose mode in `make test` target - showing structure of specs 