### PR TITLE
test(telepresence): tests proper parameter delegation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -356,6 +356,8 @@
   packages = [
     ".",
     "format",
+    "gbytes",
+    "gexec",
     "internal/assertion",
     "internal/asyncassertion",
     "internal/oraclematcher",
@@ -1001,6 +1003,7 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
+    "github.com/onsi/gomega/gexec",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/metrics",

--- a/cmd/ike/cmd/develop_test.go
+++ b/cmd/ike/cmd/develop_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path"
 
+	"github.com/onsi/gomega/gexec"
+	"github.com/spf13/afero"
+
 	. "github.com/aslakknutsen/istio-workspace/cmd/ike/cmd"
 
 	. "github.com/aslakknutsen/istio-workspace/test"
@@ -11,7 +14,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -26,23 +28,23 @@ var _ = Describe("Usage of ike develop command", func() {
 		developCmd.SilenceUsage = true
 		developCmd.SilenceErrors = true
 		NewRootCmd().AddCommand(developCmd)
-
 	})
 
 	BeforeSuite(func() {
 		// we stub existence of telepresence executable as develop command does a precondition check before execution
 		// to verify if it exists on the PATH
 		originalPath = os.Getenv("PATH")
-		telepresenceBin := TmpFile(GinkgoT(), "telepresence", "echo 'telepresence'")
-		_ = os.Setenv("PATH", path.Dir(telepresenceBin.Name()))
+		telepresenceBin, err := gexec.Build("github.com/aslakknutsen/istio-workspace/test/echo/telepresence")
+		Expect(err).ToNot(HaveOccurred())
+		_ = os.Setenv("PATH", path.Dir(telepresenceBin))
 	})
 
 	AfterSuite(func() {
 		_ = os.Setenv("PATH", originalPath)
-		CleanUp(GinkgoT())
+		gexec.CleanupBuildArtifacts()
 	})
 
-	Context("telepresence binary existence", func() {
+	Context("checking telepresence binary existence", func() {
 
 		It("should fail invoking develop cmd when telepresence binary is not on $PATH", func() {
 			oldPath := os.Getenv("PATH")
@@ -59,99 +61,132 @@ var _ = Describe("Usage of ike develop command", func() {
 
 	})
 
-	Context("with flags only", func() {
+	Describe("input validation", func() {
+		Context("with flags only", func() {
 
-		It("should fail when deployment is not specified", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234")
+			It("should fail when deployment is not specified", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234")
 
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("deployment")))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("deployment")))
+			})
+
+			It("should fail when run command is not specified", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("run")))
+			})
+
+			It("should have default port 8000 when flag not specified", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(developCmd.Flag("port").Value.String()).To(Equal("8000"))
+			})
+
+			It("should have default method inject-tcp when flag not specified", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(developCmd.Flag("method").Value.String()).To(Equal("inject-tcp"))
+			})
+
 		})
 
-		It("should fail when run command is not specified", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service")
+		Context("with config file", func() {
 
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(And(ContainSubstring("required flag(s)"), ContainSubstring("run")))
-		})
-
-		It("should have default port 8000 when flag not specified", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(developCmd.Flag("port").Value.String()).To(Equal("8000"))
-		})
-
-		It("should have default method inject-tcp when flag not specified", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--deployment", "rating-service", "--run", "'python3 rating.py'")
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(developCmd.Flag("method").Value.String()).To(Equal("inject-tcp"))
-		})
-
-	})
-
-	Context("with config file", func() {
-
-		const config = `develop:
+			const config = `develop:
   deployment: test
-  run: "python3 server.py"
-  port: 5555
+  run: "python3 config.py"
+  port: 9876
 `
-		var configFile afero.File
-
-		BeforeEach(func() {
-			configFile = TmpFile(GinkgoT(), "config.yaml", config)
-		})
-
-		It("should fail when passing non-existing config file", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--config", "~/test.yaml")
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(`Config File "test" Not Found`))
-		})
-
-		It("should load deployment from config file if not passed as flag", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234", "--config", configFile.Name())
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(developCmd.Flag("deployment").Value.String()).To(Equal("test"))
-		})
-
-		It("should use run defined in the flag not from config file", func() {
-			_, err := ValidateArgumentsOf(developCmd).Passing("-r", "'./test.sh'", "--config", configFile.Name())
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(developCmd.Flag("run").Value.String()).To(Equal(`'./test.sh'`))
-		})
-
-		Context("with ENV port variable", func() {
-
-			var oldEnv string
+			var configFile afero.File
 
 			BeforeEach(func() {
-				oldEnv = os.Getenv("IKE_DEVELOP_PORT")
-				_ = os.Setenv("IKE_DEVELOP_PORT", "4321")
+				configFile = TmpFile(GinkgoT(), "config.yaml", config)
 			})
 
 			AfterEach(func() {
-				_ = os.Setenv("IKE_DEVELOP_PORT", oldEnv)
+				CleanUp(GinkgoT())
 			})
 
-			It("should use environment variable over config file", func() {
-				_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())
+			It("should fail when passing non-existing config file", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--config", "~/test.yaml")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`Config File "test" Not Found`))
+			})
+
+			It("should load deployment from config file if not passed as flag", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1234", "--config", configFile.Name())
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(developCmd.Flag("port").Value.String()).To(Equal("4321"))
+				Expect(developCmd.Flag("deployment").Value.String()).To(Equal("test"))
 			})
 
-			It("should use flag over environment variable", func() {
-				_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1111", "--config", configFile.Name())
+			It("should use run defined in the flag not from config file", func() {
+				_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name(), "--run", "'./test.sh'")
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(developCmd.Flag("port").Value.String()).To(Equal("1111"))
+				Expect(developCmd.Flag("run").Value.String()).To(Equal(`'./test.sh'`))
 			})
 
+			Context("with ENV port variable", func() {
+
+				var oldEnv string
+
+				BeforeEach(func() {
+					oldEnv = os.Getenv("IKE_DEVELOP_PORT")
+					_ = os.Setenv("IKE_DEVELOP_PORT", "4321")
+				})
+
+				AfterEach(func() {
+					_ = os.Setenv("IKE_DEVELOP_PORT", oldEnv)
+				})
+
+				It("should use environment variable over config file", func() {
+					_, err := ValidateArgumentsOf(developCmd).Passing("--config", configFile.Name())
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(developCmd.Flag("port").Value.String()).To(Equal("4321"))
+				})
+
+				It("should use flag over environment variable", func() {
+					_, err := ValidateArgumentsOf(developCmd).Passing("--port", "1111", "--config", configFile.Name())
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(developCmd.Flag("port").Value.String()).To(Equal("1111"))
+				})
+
+			})
+		})
+	})
+
+	Describe("telepresence arguments delegation", func() {
+
+		It("should pass all specified parameters", func() {
+			output, err := Execute(developCmd).Passing("--deployment", "rating-service",
+				"--run", "'python3 rating.py'",
+				"--port", "4321",
+				"--method", "vpn-tcp")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("--swap-deployment rating-service"))
+			Expect(output).To(ContainSubstring("--expose 4321"))
+			Expect(output).To(ContainSubstring("--method vpn-tcp"))
+			Expect(output).To(ContainSubstring("--run 'python3 rating.py'"))
+		})
+
+		It("should pass specified parameters and defaults", func() {
+			output, err := Execute(developCmd).Passing("--deployment", "rating-service",
+				"--run", "'python3 rating.py'")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("--swap-deployment rating-service"))
+			Expect(output).To(ContainSubstring("--expose 8000"))
+			Expect(output).To(ContainSubstring("--method inject-tcp"))
+			Expect(output).To(ContainSubstring("--run 'python3 rating.py'"))
 		})
 
 	})

--- a/test/cmd.go
+++ b/test/cmd.go
@@ -16,6 +16,11 @@ func ValidateArgumentsOf(command *cobra.Command) *Cmd {
 	return (*Cmd)(command)
 }
 
+// ValidateArgumentsOf will not run actual command but let the initialization and validation happen
+func Execute(command *cobra.Command) *Cmd {
+	return (*Cmd)(command)
+}
+
 func (command *Cmd) Passing(args ...string) (output string, err error) {
 	cmd := (*cobra.Command)(command)
 	output, err = executeCommand(cmd, args...)

--- a/test/echo/telepresence/main.go
+++ b/test/echo/telepresence/main.go
@@ -1,0 +1,10 @@
+// Test double that echoes passed arguments and flags.
+// This is handy in validating passed arguments to target binary
+package main
+
+import "os"
+import "fmt"
+
+func main() {
+	fmt.Println(os.Args)
+}

--- a/test/tmp_file.go
+++ b/test/tmp_file.go
@@ -46,7 +46,7 @@ func TmpFile(t TestReporter, fileName, content string) afero.File {
 	return file
 }
 
-// CleanUp removes all files in our test registry and calls `t.Error` if something goes wrong.
+// CleanUp removes all files in our test registry and calls `t.Errorf` if something goes wrong.
 func CleanUp(t TestReporter) {
 	for _, filePath := range Files {
 		if err := appFs.RemoveAll(filePath); err != nil {


### PR DESCRIPTION
Adds tests verifying if we pass arguments to `telepresence` correctly.

This is achieved by swapping actual `telepresence` binary with test double - simple executable printing out all the arguments which were passed. That's achieved by Ginko's `gexec.Build` invoked before suite which builds a simple program included in this PR (`test/echo/telepresence/main.go`) and makes it `telepresence` command available in the `$PATH`.

In addition structure of Specs has been slightly changed.